### PR TITLE
Add ability to send image with sendMessage

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "machinepack-twilio",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "description": "Interact with the Twilio API; buy numbers, release numbers, send messages, etc.",
   "keywords": [
     "machinepack",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "url": "git@github.com:parkeragee/machinepack-twilio.git"
   },
   "machinepack": {
+    "iconSrc": "https://s3-us-west-1.amazonaws.com/machinepack-icons/machinepack_twilio.png",
     "machineDir": "machines",
     "machines": [
       "send-message",


### PR DESCRIPTION
Adds the "mediaUrl" input which allows user to specify the URL of an image to include with the text message.  Also bumps minor version to ensure syncing with node-machine.org and treeline.io.
